### PR TITLE
CI: generate subiquity types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,12 +64,13 @@ jobs:
       - run: dart format --set-exit-if-changed .
 
   generate:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
       - uses: dart-lang/setup-dart@v1
+      - run: make generate
       - run: dart pub get
       - run: dart run build_runner build --delete-conflicting-outputs
       - name: Warn about outdated generated files


### PR DESCRIPTION
Follow-up for #3 to run the generator script in the CI to ensure that `types.py` and `types.dart` stay in sync.

NOTE: It's fine to merge a subiquity update that leaves the two out of sync. The bot will automatically open a PR with newly generated Dart files.