### PR TITLE
Revert "Update dependency xdg_directories to v1"

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   path: ^1.8.0
   synchronized: ^3.0.0
   ubuntu_logger: ^0.0.1
-  xdg_directories: ^1.0.0
+  xdg_directories: ^0.2.0
 
 dev_dependencies:
   build_runner: ^2.2.0


### PR DESCRIPTION
Reverts canonical/subiquity_client.dart#16 because it conflicts with gsettings.dart.

```
Because every version of subiquity_client from path depends on xdg_directories ^1.0.0 and gsettings >=0.2.0 depends on xdg_directories ^0.2.0, subiquity_client from path is incompatible with gsettings >=0.2.0.
So, because ubuntu_desktop_installer depends on both gsettings ^0.2.5 and subiquity_client from path, version solving failed.
```