### PR TITLE
CI: use `make install_deps` for subiquity dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install subiquity dependencies
         working-directory: ./subiquity
-        run: sudo ./scripts/installdeps.sh
+        run: make install_deps
 
       - name: Prepare environment for subiquity
         run: |


### PR DESCRIPTION
For the same reason as:
- https://github.com/canonical/ubuntu-desktop-installer/pull/1407
- https://github.com/canonical/ubuntu-desktop-installer/pull/1414

https://github.com/canonical/subiquity_client.dart/actions/runs/4194412472/jobs/7272542925
