### PR TITLE
Initial Active Directory support

### DIFF
--- a/test/subiquity_client_test.dart
+++ b/test/subiquity_client_test.dart
@@ -493,6 +493,61 @@ void main() {
       expect(change.ready, isFalse);
       expect(change.err, isNull);
     });
+
+    test('AD support', () async {
+      expect(await client.hasActiveDirectorySupport(), anyOf(isTrue, isFalse));
+    });
+
+    test('AD info', () async {
+      final info = ADConnectionInfo(
+        domainName: 'foo.bar.baz',
+        adminName: 'admin',
+        password: 'password',
+      );
+      await client.setActiveDirectory(info);
+      expect(await client.getActiveDirectory(), info);
+    });
+
+    test('AD domain', () async {
+      expect(
+        await client.checkActiveDirectoryDomainName(''),
+        [AdDomainNameValidation.EMPTY],
+      );
+      expect(
+        await client.checkActiveDirectoryDomainName('!"#¤%&/(=)'),
+        [AdDomainNameValidation.INVALID_CHARS],
+      );
+      expect(
+        await client.checkActiveDirectoryDomainName('foo.bar.baz'),
+        [AdDomainNameValidation.OK],
+      );
+    });
+
+    test('AD admin', () async {
+      expect(
+        await client.checkActiveDirectoryAdminName(''),
+        AdAdminNameValidation.EMPTY,
+      );
+      expect(
+        await client.checkActiveDirectoryAdminName('!"#¤%&/(=)'),
+        AdAdminNameValidation.INVALID_CHARS,
+      );
+      expect(
+        await client.checkActiveDirectoryAdminName('foo.bar.baz'),
+        AdAdminNameValidation.OK,
+      );
+    });
+
+    test('AD password', () async {
+      expect(
+        await client.checkActiveDirectoryPassword(''),
+        AdPasswordValidation.EMPTY,
+      );
+      expect(
+        await client.checkActiveDirectoryPassword('!"#¤%&/(=)'),
+        AdPasswordValidation.OK,
+      );
+    });
   });
 
   group('wsl', () {


### PR DESCRIPTION
There's still [more AD-related API coming](https://github.com/canonical/subiquity/pull/1572) but this PR implements API that has been added to Subiquity so far to get us going with the GUI-side work:

```python
    class active_directory:
        def GET() -> Optional[ADConnectionInfo]: ...
        # POST expects input validated by the check methods below:
        def POST(data: Payload[ADConnectionInfo]) -> None: ...

        class has_support:
            """ Whether the live system supports Active Directory or not.
                Network status is not considered.
                Clients should call this before showing the AD page. """
            def GET() -> bool: ...

        class check_domain_name:
            def POST(domain_name: Payload[str]) \
                -> List[AdDomainNameValidation]: ...

        class check_admin_name:
            def POST(admin_name: Payload[str]) -> AdAdminNameValidation: ...

        class check_password:
            def POST(password: Payload[str]) -> AdPasswordValidation: ...
```

https://github.com/canonical/subiquity/blob/9d5779891e81bea8f2629303a4f9fe179cff4cd7/subiquity/common/apidef.py#L416-L435