### PR TITLE
Remove SubiquityClient.isOpen

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -42,9 +42,6 @@ class SubiquityException implements Exception {
 class SubiquityClient {
   final _client = HttpClient();
   Endpoint? _endpoint;
-  final _isOpen = Completer<bool>();
-
-  Future<bool> get isOpen => _isOpen.future;
 
   Uri url(String unencodedPath, [Map<String, dynamic>? queryParameters]) =>
       Uri.http(_endpoint!.authority, unencodedPath, queryParameters);
@@ -55,7 +52,6 @@ class SubiquityClient {
     _client.connectionFactory = (uri, proxyHost, proxyPort) async {
       return Socket.startConnect(endpoint.address, endpoint.port);
     };
-    _isOpen.complete(true);
   }
 
   Future<void> close() async {

--- a/test/subiquity_client_test.dart
+++ b/test/subiquity_client_test.dart
@@ -10,15 +10,6 @@ void main() {
   late SubiquityServer testServer;
   late SubiquityClient client;
 
-  test('initialization', () async {
-    client = SubiquityClient();
-    final isOpen = client.isOpen;
-    final address = Endpoint.unix('');
-    Future.delayed(Duration(milliseconds: 1)).then((_) => client.open(address));
-    await expectLater(isOpen, completes);
-    expect(await isOpen, isTrue);
-  });
-
   group('subiquity process', () {
     test('set additional environment before starting the process', () async {
       const foo = '42';


### PR DESCRIPTION
No longer used: canonical/ubuntu-desktop-installer#1433

Services and models couldn't rely on isOpen because Subiquity is not immediately ready for use after opening the socket but needs some initialization first.