### PR TITLE
Use JsonCodec for query params and responses

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,6 @@ environment:
   sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  dartx: ^1.0.0
   freezed_annotation: ^2.1.0
   json_annotation: ^4.6.0
   meta: ^1.7.0


### PR DESCRIPTION
Split off from #25.

`jsonEncode()` takes care of adding quotes around strings, and `jsonDecode()` returns strings without extra quotes and booleans as booleans. This is essentially the same as what Subiquity does in Python i.e. serializing and de-serializing to/from JSON. As a bonus, we get rid of the silly `dartx` dependency for... removing quotes, tada! (: