### PR TITLE
Move repetitive request.close() calls into _receive()

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -60,9 +60,10 @@ class SubiquityClient {
 
   Future<T> _receive<T>(
     String method,
-    HttpClientResponse response, [
+    HttpClientRequest request, [
     String Function(String, String) formatResponseLog = _formatResponseLog,
   ]) async {
+    final response = await request.close();
     final responseStr = await response.transform(utf8.decoder).join();
     if (response.statusCode != 200) {
       throw SubiquityException(method, response.statusCode, responseStr);
@@ -73,10 +74,10 @@ class SubiquityClient {
 
   Future<Map<String, dynamic>> _receiveJson(
     String method,
-    HttpClientResponse response, [
+    HttpClientRequest request, [
     String Function(String, String) formatResponseLog = _formatResponseLog,
   ]) async {
-    return _receive<Map<String, dynamic>>(method, response, formatResponseLog);
+    return _receive<Map<String, dynamic>>(method, request, formatResponseLog);
   }
 
   Future<HttpClientRequest> _openUrl(String method, Uri url) async {
@@ -89,125 +90,103 @@ class SubiquityClient {
 
   Future<Variant> variant() async {
     final request = await _openUrl('GET', url('meta/client_variant'));
-    final response = await request.close();
-
-    final responseStr = await _receive('variant()', response);
+    final responseStr = await _receive('variant()', request);
     return VariantString.fromString(responseStr);
   }
 
   Future<void> setVariant(Variant variant) async {
     final params = {'variant': jsonEncode(variant.toVariantString())};
     final request = await _openUrl('POST', url('meta/client_variant', params));
-    final response = await request.close();
-    await _receive('setVariant("$variant")', response);
+    await _receive('setVariant("$variant")', request);
   }
 
   Future<SourceSelectionAndSetting> source() async {
     final request = await _openUrl('GET', url('source'));
-    final response = await request.close();
-
-    final json = await _receiveJson('source()', response);
+    final json = await _receiveJson('source()', request);
     return SourceSelectionAndSetting.fromJson(json);
   }
 
   Future<void> setSource(String sourceId) async {
     final params = {'source_id': jsonEncode(sourceId)};
     final request = await _openUrl('POST', url('source', params));
-    final response = await request.close();
-    await _receive('setSource("$sourceId")', response);
+    await _receive('setSource("$sourceId")', request);
   }
 
   Future<String> locale() async {
     final request = await _openUrl('GET', url('locale'));
-    final response = await request.close();
-    return _receive('locale()', response);
+    return _receive('locale()', request);
   }
 
   Future<void> setLocale(String locale) async {
     final request = await _openUrl('POST', url('locale'));
     request.write('"$locale"');
-    final response = await request.close();
-    await _receive('setLocale("$locale")', response);
+    await _receive('setLocale("$locale")', request);
   }
 
   Future<KeyboardSetup> keyboard() async {
     final request = await _openUrl('GET', url('keyboard'));
-    final response = await request.close();
-
-    final keyboardJson = await _receiveJson('keyboard()', response);
+    final keyboardJson = await _receiveJson('keyboard()', request);
     return KeyboardSetup.fromJson(keyboardJson);
   }
 
   Future<void> setKeyboard(KeyboardSetting setting) async {
     final request = await _openUrl('POST', url('keyboard'));
     request.write(jsonEncode(setting.toJson()));
-    final response = await request.close();
-    await _receive('setKeyboard(${jsonEncode(setting.toJson())})', response);
+    await _receive('setKeyboard(${jsonEncode(setting.toJson())})', request);
   }
 
   Future<void> setInputSource(KeyboardSetting setting) async {
     final request = await _openUrl('POST', url('keyboard/input_source'));
     request.write(jsonEncode(setting.toJson()));
-    final response = await request.close();
-    await _receive('setInputSource(${jsonEncode(setting.toJson())})', response);
+    await _receive('setInputSource(${jsonEncode(setting.toJson())})', request);
   }
 
   Future<String> proxy() async {
     final request = await _openUrl('GET', url('proxy'));
-    final response = await request.close();
-    return _receive('proxy()', response);
+    return _receive('proxy()', request);
   }
 
   Future<void> setProxy(String proxy) async {
     final request = await _openUrl('POST', url('proxy'));
     request.write('"$proxy"');
-    final response = await request.close();
-    await _receive('setProxy("$proxy")', response);
+    await _receive('setProxy("$proxy")', request);
   }
 
   Future<MirrorGet> mirror() async {
     final request = await _openUrl('GET', url('mirror'));
-    final response = await request.close();
-
-    final json = await _receiveJson('mirror()', response);
+    final json = await _receiveJson('mirror()', request);
     return MirrorGet.fromJson(json);
   }
 
   Future<MirrorPostResponse> setMirror(MirrorPost? mirror) async {
     final request = await _openUrl('POST', url('mirror'));
     request.write(jsonEncode(mirror?.toJson()));
-    final response = await request.close();
-    final responseStr = await _receive('setMirror("$mirror")', response);
+    final responseStr = await _receive('setMirror("$mirror")', request);
     return MirrorPostResponse.values.byName(responseStr);
   }
 
   Future<bool> freeOnly() async {
     final request = await _openUrl('GET', url('meta/free_only'));
-    final response = await request.close();
-    return _receive('freeOnly()', response);
+    return _receive('freeOnly()', request);
   }
 
   // ignore: avoid_positional_boolean_parameters
   Future<void> setFreeOnly(bool enable) async {
     final params = {'enable': jsonEncode(enable)};
     final request = await _openUrl('POST', url('meta/free_only', params));
-    final response = await request.close();
-    await _receive('setFreeOnly("$freeOnly")', response);
+    await _receive('setFreeOnly("$freeOnly")', request);
   }
 
   Future<IdentityData> identity() async {
     final request = await _openUrl('GET', url('identity'));
-    final response = await request.close();
-
-    final identityJson = await _receiveJson('identity()', response);
+    final identityJson = await _receiveJson('identity()', request);
     return IdentityData.fromJson(identityJson);
   }
 
   Future<void> setIdentity(IdentityData identity) async {
     final request = await _openUrl('POST', url('identity'));
     request.write(jsonEncode(identity.toJson()));
-    final response = await request.close();
-    await _receive('setIdentity(${jsonEncode(identity.toJson())})', response);
+    await _receive('setIdentity(${jsonEncode(identity.toJson())})', request);
   }
 
   Future<UsernameValidation> validateUsername(String username) async {
@@ -220,25 +199,20 @@ class SubiquityClient {
         params,
       ),
     );
-    final response = await request.close();
-
-    final respStr = await _receive('identity/validate_username()', response);
+    final respStr = await _receive('identity/validate_username()', request);
     return UsernameValidation.values.byName(respStr);
   }
 
   Future<TimeZoneInfo> timezone() async {
     final request = await _openUrl('GET', url('timezone'));
-    final response = await request.close();
-
-    final timezoneJson = await _receiveJson('timezone()', response);
+    final timezoneJson = await _receiveJson('timezone()', request);
     return TimeZoneInfo.fromJson(timezoneJson);
   }
 
   Future<void> setTimezone(String timezone) async {
     final params = {'tz': jsonEncode(timezone)};
     final request = await _openUrl('POST', url('timezone', params));
-    final response = await request.close();
-    await _receive('setTimezone("$timezone")', response);
+    await _receive('setTimezone("$timezone")', request);
   }
 
   /// Get the installer state.
@@ -248,12 +222,10 @@ class SubiquityClient {
     if (current != null) {
       final params = {'cur': jsonEncode(current.name)};
       final request = await _openUrl('GET', url('meta/status', params));
-      final response = await request.close();
-      statusJson = await _receiveJson('status("${current.name}")', response);
+      statusJson = await _receiveJson('status("${current.name}")', request);
     } else {
       final request = await _openUrl('GET', url('meta/status'));
-      final response = await request.close();
-      statusJson = await _receiveJson('status()', response);
+      statusJson = await _receiveJson('status()', request);
     }
 
     final result = ApplicationStatus.fromJson(statusJson);
@@ -266,41 +238,34 @@ class SubiquityClient {
   Future<void> markConfigured(List<String> endpointNames) async {
     final params = {'endpoint_names': jsonEncode(endpointNames)};
     final request = await _openUrl('POST', url('meta/mark_configured', params));
-    final response = await request.close();
-    await _receive('markConfigured(${jsonEncode(endpointNames)})', response);
+    await _receive('markConfigured(${jsonEncode(endpointNames)})', request);
   }
 
   /// Confirm that the installation should proceed.
   Future<void> confirm(String tty) async {
     final params = {'tty': jsonEncode(tty)};
     final request = await _openUrl('POST', url('meta/confirm', params));
-    final response = await request.close();
-    await _receive('confirm("$tty")', response);
+    await _receive('confirm("$tty")', request);
   }
 
   /// Returns whether RST is turned on.
   Future<bool> hasRst() async {
     final request = await _openUrl('GET', url('storage/has_rst'));
-    final response = await request.close();
-    return _receive('hasRst()', response);
+    return _receive('hasRst()', request);
   }
 
   /// Returns whether any disks contain BitLocker partitions.
   Future<bool> hasBitLocker() async {
     final request = await _openUrl('GET', url('storage/has_bitlocker'));
-    final response = await request.close();
-
-    final disks = await _receive<List>('hasBitLocker()', response);
+    final disks = await _receive<List>('hasBitLocker()', request);
     return disks.isNotEmpty;
   }
 
   Future<GuidedStorageResponseV2> getGuidedStorageV2({bool wait = true}) async {
     final params = {'wait': jsonEncode(wait)};
     final request = await _openUrl('GET', url('storage/v2/guided', params));
-    final response = await request.close();
-
     final responseJson =
-        await _receiveJson("getGuidedStorageV2('$wait')", response);
+        await _receiveJson("getGuidedStorageV2('$wait')", request);
     return GuidedStorageResponseV2.fromJson(responseJson);
   }
 
@@ -308,7 +273,6 @@ class SubiquityClient {
       GuidedChoiceV2 choice) async {
     final request = await _openUrl('POST', url('storage/v2/guided'));
     request.write(jsonEncode(choice.toJson()));
-    final response = await request.close();
 
     String? hidePassword(String? password) {
       return password == null ? null : '*' * password.length;
@@ -332,7 +296,7 @@ class SubiquityClient {
 
     final responseJson = await _receiveJson(
       'setGuidedStorageV2(${hidePasswordRequest(choice)})',
-      response,
+      request,
       hidePasswordResponse,
     );
     return GuidedStorageResponseV2.fromJson(responseJson);
@@ -340,34 +304,26 @@ class SubiquityClient {
 
   Future<StorageResponseV2> getOriginalStorageV2() async {
     final request = await _openUrl('GET', url('storage/v2/orig_config'));
-    final response = await request.close();
-
-    final responseJson = await _receiveJson('getOriginalStorageV2()', response);
+    final responseJson = await _receiveJson('getOriginalStorageV2()', request);
     return StorageResponseV2.fromJson(responseJson);
   }
 
   Future<StorageResponseV2> getStorageV2({bool wait = true}) async {
     final params = {'wait': jsonEncode(wait)};
     final request = await _openUrl('GET', url('storage/v2', params));
-    final response = await request.close();
-
-    final responseJson = await _receiveJson('getStorageV2()', response);
+    final responseJson = await _receiveJson('getStorageV2()', request);
     return StorageResponseV2.fromJson(responseJson);
   }
 
   Future<StorageResponseV2> setStorageV2() async {
     final request = await _openUrl('POST', url('storage/v2'));
-    final response = await request.close();
-
-    final responseJson = await _receiveJson('setStorageV2()', response);
+    final responseJson = await _receiveJson('setStorageV2()', request);
     return StorageResponseV2.fromJson(responseJson);
   }
 
   Future<StorageResponseV2> resetStorageV2() async {
     final request = await _openUrl('POST', url('storage/v2/reset'));
-    final response = await request.close();
-
-    final responseJson = await _receiveJson('resetStorageV2()', response);
+    final responseJson = await _receiveJson('resetStorageV2()', request);
     return StorageResponseV2.fromJson(responseJson);
   }
 
@@ -379,10 +335,8 @@ class SubiquityClient {
       'gap': gap.toJson(),
       'partition': partition.toJson(),
     }));
-    final response = await request.close();
-
     final responseJson =
-        await _receiveJson('addPartition(${disk.id}, $partition)', response);
+        await _receiveJson('addPartition(${disk.id}, $partition)', request);
     return StorageResponseV2.fromJson(responseJson);
   }
 
@@ -393,10 +347,8 @@ class SubiquityClient {
       'disk_id': disk.id,
       'partition': partition.toJson(),
     }));
-    final response = await request.close();
-
     final responseJson =
-        await _receiveJson('editPartition(${disk.id}, $partition)', response);
+        await _receiveJson('editPartition(${disk.id}, $partition)', request);
     return StorageResponseV2.fromJson(responseJson);
   }
 
@@ -407,10 +359,8 @@ class SubiquityClient {
       'disk_id': disk.id,
       'partition': partition.toJson(),
     }));
-    final response = await request.close();
-
     final responseJson =
-        await _receiveJson('deletePartition(${disk.id}, $partition)', response);
+        await _receiveJson('deletePartition(${disk.id}, $partition)', request);
     return StorageResponseV2.fromJson(responseJson);
   }
 
@@ -418,20 +368,16 @@ class SubiquityClient {
     final params = {'disk_id': jsonEncode(disk.id)};
     final request =
         await _openUrl('POST', url('storage/v2/add_boot_partition', params));
-    final response = await request.close();
-
     final responseJson =
-        await _receiveJson('addBootPartitionV2(${disk.id})', response);
+        await _receiveJson('addBootPartitionV2(${disk.id})', request);
     return StorageResponseV2.fromJson(responseJson);
   }
 
   Future<StorageResponseV2> reformatDiskV2(Disk disk) async {
     final request = await _openUrl('POST', url('storage/v2/reformat_disk'));
     request.write(jsonEncode({'disk_id': disk.id}));
-    final response = await request.close();
-
     final responseJson =
-        await _receiveJson('reformatDiskV2(${disk.id})', response);
+        await _receiveJson('reformatDiskV2(${disk.id})', request);
     return StorageResponseV2.fromJson(responseJson);
   }
 
@@ -459,40 +405,32 @@ class SubiquityClient {
 
   Future<WSLSetupOptions> wslSetupOptions() async {
     final request = await _openUrl('GET', url('wslsetupoptions'));
-    final response = await request.close();
-
-    final json = await _receiveJson('wslsetupoptions()', response);
+    final json = await _receiveJson('wslsetupoptions()', request);
     return WSLSetupOptions.fromJson(json);
   }
 
   Future<void> setWslSetupOptions(WSLSetupOptions options) async {
     final request = await _openUrl('POST', url('wslsetupoptions'));
     request.write(jsonEncode(options.toJson()));
-    final response = await request.close();
     await _receive(
-        'setWslSetupOptions(${jsonEncode(options.toJson())})', response);
+        'setWslSetupOptions(${jsonEncode(options.toJson())})', request);
   }
 
   Future<WSLConfigurationBase> wslConfigurationBase() async {
     final request = await _openUrl('GET', url('wslconfbase'));
-    final response = await request.close();
-
-    final json = await _receiveJson('wslconfbase()', response);
+    final json = await _receiveJson('wslconfbase()', request);
     return WSLConfigurationBase.fromJson(json);
   }
 
   Future<void> setWslConfigurationBase(WSLConfigurationBase conf) async {
     final request = await _openUrl('POST', url('wslconfbase'));
     request.write(jsonEncode(conf.toJson()));
-    final response = await request.close();
-    await _receive('setWslconfbase(${jsonEncode(conf.toJson())})', response);
+    await _receive('setWslconfbase(${jsonEncode(conf.toJson())})', request);
   }
 
   Future<WSLConfigurationAdvanced> wslConfigurationAdvanced() async {
     final request = await _openUrl('GET', url('wslconfadvanced'));
-    final response = await request.close();
-
-    final json = await _receiveJson('wslconfadvanced()', response);
+    final json = await _receiveJson('wslconfadvanced()', request);
     return WSLConfigurationAdvanced.fromJson(json);
   }
 
@@ -500,67 +438,56 @@ class SubiquityClient {
       WSLConfigurationAdvanced conf) async {
     final request = await _openUrl('POST', url('wslconfadvanced'));
     request.write(jsonEncode(conf.toJson()));
-    final response = await request.close();
-    await _receive(
-        'setWslconfadvanced(${jsonEncode(conf.toJson())})', response);
+    await _receive('setWslconfadvanced(${jsonEncode(conf.toJson())})', request);
   }
 
   Future<AnyStep> getKeyboardStep([String step = '0']) async {
     final params = {'index': jsonEncode(step)};
     final request = await _openUrl('GET', url('keyboard/steps', params));
-    final response = await request.close();
-
-    final json = await _receiveJson('getKeyboardStep($step)', response);
+    final json = await _receiveJson('getKeyboardStep($step)', request);
     return AnyStep.fromJson(json);
   }
 
   Future<DriversResponse> getDrivers() async {
     final request = await _openUrl('GET', url('drivers'));
-    final response = await request.close();
-    final json = await _receiveJson('getDrivers()', response);
+    final json = await _receiveJson('getDrivers()', request);
     return DriversResponse.fromJson(json);
   }
 
   Future<void> setDrivers({required bool install}) async {
     final request = await _openUrl('POST', url('drivers'));
     request.write(jsonEncode(<String, dynamic>{'install': install}));
-    final response = await request.close();
-    await _receive('setDrivers($install)', response);
+    await _receive('setDrivers($install)', request);
   }
 
   Future<CodecsData> getCodecs() async {
     final request = await _openUrl('GET', url('codecs'));
-    final response = await request.close();
-    final json = await _receiveJson('getCodecs()', response);
+    final json = await _receiveJson('getCodecs()', request);
     return CodecsData.fromJson(json);
   }
 
   Future<void> setCodecs({required bool install}) async {
     final request = await _openUrl('POST', url('codecs'));
     request.write(jsonEncode(<String, dynamic>{'install': install}));
-    final response = await request.close();
-    await _receive('setCodecs($install)', response);
+    await _receive('setCodecs($install)', request);
   }
 
   Future<RefreshStatus> checkRefresh({bool wait = true}) async {
     final params = {'wait': jsonEncode(wait)};
     final request = await _openUrl('GET', url('refresh', params));
-    final response = await request.close();
-    final json = await _receiveJson('checkRefresh()', response);
+    final json = await _receiveJson('checkRefresh()', request);
     return RefreshStatus.fromJson(json);
   }
 
   Future<String> startRefresh() async {
     final request = await _openUrl('POST', url('refresh'));
-    final response = await request.close();
-    return _receive('startRefresh()', response);
+    return _receive('startRefresh()', request);
   }
 
   Future<Change> getRefreshProgress(String changeId) async {
     final params = {'change_id': jsonEncode(changeId)};
     final request = await _openUrl('GET', url('refresh/progress', params));
-    final response = await request.close();
-    final json = await _receiveJson('getRefreshProgress($changeId)', response);
+    final json = await _receiveJson('getRefreshProgress($changeId)', request);
     return Change.fromJson(json);
   }
 }


### PR DESCRIPTION
Split off from #25.

Instead of awaiting request.close() in every single method and then passing the response to _receive(), just pass the response and await once in _receive().