### PR TITLE
setInputSource(): add missing user-argument

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -126,8 +126,10 @@ class SubiquityClient {
     await _receive('setKeyboard($setting)', request);
   }
 
-  Future<void> setInputSource(KeyboardSetting setting) async {
-    final request = await _openUrl('POST', url('keyboard/input_source'));
+  Future<void> setInputSource(KeyboardSetting setting, {String? user}) async {
+    final params = {if (user != null) 'user': jsonEncode(user)};
+    final request =
+        await _openUrl('POST', url('keyboard/input_source', params));
     request.write(jsonEncode(setting.toJson()));
     await _receive('setInputSource($setting)', request);
   }

--- a/test/subiquity_client_test.dart
+++ b/test/subiquity_client_test.dart
@@ -139,6 +139,7 @@ void main() {
     test('input source', () async {
       const ks = KeyboardSetting(layout: 'fr', variant: 'latin9');
       await expectLater(client.setInputSource(ks), completes);
+      await expectLater(client.setInputSource(ks, user: 'flavor'), completes);
     });
 
     test('has rst', () async {


### PR DESCRIPTION
Subiquity runs as root. It doesn't know the desktop live session user. The GUI must pass the appropriate username to make it possible for Subiquity to change the desktop input source for the live session user. It defaults to 'ubuntu' which won't work for flavors that may have a different live session username.

The respective Subiquity API was added in https://github.com/canonical/subiquity/pull/1388 but the user-argument was forgotten from the Dart API. :man_shrugging: 

Ref: https://github.com/canonical/ubuntu-flavor-installer/issues/10