### PR TITLE
Tests: add missing --storage-version=2

### DIFF
--- a/test/subiquity_client_test.dart
+++ b/test/subiquity_client_test.dart
@@ -61,6 +61,7 @@ void main() {
       final socketPath = await testServer.start(args: [
         '--machine-config=examples/simple.json',
         '--source-catalog=examples/mixed-sources.yaml',
+        '--storage-version=2',
         '--bootloader=uefi',
       ]);
       client.open(socketPath);


### PR DESCRIPTION
Required for #47 to pass tests. Amazing that the storage v2 tests even passed previously...