### PR TITLE
Pin dart_style version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,10 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.2.0
+  # TODO: dart_style 2.3.0 has some formatting changes that cause differences
+  # between `dart format` and `dart pub run build_runner`. Remove this when the
+  # latest stable Dart SDK uses dart_style 2.3.0+.
+  dart_style: 2.2.5
   freezed: ^2.3.2
   json_serializable: ^6.3.1
   lints: ^2.0.1


### PR DESCRIPTION
dart_style 2.3.0 has formatting changes that cause differences between `dart format` and `dart pub run build_runner`. Pin version 2.2.x until the latest stable Dart SDK uses dart_style 2.3.0+.

- https://github.com/canonical/subiquity_client.dart/pull/52
- https://github.com/canonical/subiquity_client.dart/actions/runs/4411466308/jobs/7729993034

<details><summary>diff</summary>

```diff
diff --git a/test/status_monitor_test.mocks.dart b/test/status_monitor_test.mocks.dart
index f500667..dd41dff 100644
--- a/test/status_monitor_test.mocks.dart
+++ b/test/status_monitor_test.mocks.dart
@@ -167,11 +167,10 @@ class MockHttpClient extends _i1.Mock implements _i2.HttpClient {
   @override
   set authenticate(
           _i4.Future<bool> Function(
-    Uri,
-    String,
-    String?,
-  )?
-              f) =>
+            Uri,
+            String,
+            String?,
+          )? f) =>
       super.noSuchMethod(
         Invocation.setter(
           #authenticate,
@@ -[18](https://github.com/canonical/subiquity_client.dart/actions/runs/4411466308/jobs/7729993034#step:7:19)2,11 +181,10 @@ class MockHttpClient extends _i1.Mock implements _i2.HttpClient {
   @override
   set connectionFactory(
           _i4.Future<_i2.ConnectionTask<_i2.Socket>> Function(
-    Uri,
-    String?,
-    int?,
-  )?
-              f) =>
+            Uri,
+            String?,
+            int?,
+          )? f) =>
       super.noSuchMethod(
         Invocation.setter(
           #connectionFactory,
@@ -[20](https://github.com/canonical/subiquity_client.dart/actions/runs/4411466308/jobs/7729993034#step:7:21)5,12 +203,11 @@ class MockHttpClient extends _i1.Mock implements _i2.HttpClient {
   @override
   set authenticateProxy(
           _i4.Future<bool> Function(
-    String,
-    int,
-    String,
-    String?,
-  )?
-              f) =>
+            String,
+            int,
+            String,
+            String?,
+          )? f) =>
       super.noSuchMethod(
         Invocation.setter(
           #authenticateProxy,
@@ -2[21](https://github.com/canonical/subiquity_client.dart/actions/runs/4411466308/jobs/7729993034#step:7:22),11 +218,10 @@ class MockHttpClient extends _i1.Mock implements _i2.HttpClient {
   @override
   set badCertificateCallback(
           bool Function(
-    _i2.X509Certificate,
-    String,
-    int,
-  )?
-              callback) =>
+            _i2.X509Certificate,
+            String,
+            int,
+          )? callback) =>
       super.noSuchMethod(
         Invocation.setter(
           #badCertificateCallback,
@@ -1092,10 +1088,9 @@ class MockHttpClientResponse extends _i1.Mock
   @override
   _i4.Future<List<int>> reduce(
           List<int> Function(
-    List<int>,
-    List<int>,
-  )?
-              combine) =>
+            List<int>,
+            List<int>,
+          )? combine) =>
       (super.noSuchMethod(
         Invocation.method(
           #reduce,
@@ -1109,8 +1104,7 @@ class MockHttpClientResponse extends _i1.Mock
     S Function(
       S,
       List<int>,
-    )?
-        combine,
+    )? combine,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1234,8 +1[22](https://github.com/canonical/subiquity_client.dart/actions/runs/4411466308/jobs/7729993034#step:7:23)8,7 @@ class MockHttpClientResponse extends _i1.Mock
           [bool Function(
             List<int>,
             List<int>,
-          )?
-              equals]) =>
+          )? equals]) =>
       (super.noSuchMethod(
         Invocation.method(
           #distinct,
```
</details>