### PR TITLE
Switch back to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: gitsubmodule
+    directory: /
+    schedule:
+        interval: "daily"

--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
     "git-submodules",
     "github-actions",
     "pub"
-  ],
+  ]
   "git-submodules": {
     "enabled": true
   }

--- a/renovate.json
+++ b/renovate.json
@@ -10,13 +10,5 @@
   ],
   "git-submodules": {
     "enabled": true
-  },
-  "packageRules": [
-    {
-      "managers": [
-        "git-submodules"
-      ],
-      "automerge": true
-    }
-  ]
+  }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -2,8 +2,5 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>ubuntu-flutter-community/renovate-config"
-  ],
-  "git-submodules": {
-    "enabled": true
-  }
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -3,11 +3,6 @@
   "extends": [
     "github>ubuntu-flutter-community/renovate-config"
   ],
-  "enabledManagers": [
-    "git-submodules",
-    "github-actions",
-    "pub"
-  ]
   "git-submodules": {
     "enabled": true
   }


### PR DESCRIPTION
Renovate's experimental Git submodule support cannot handle our `ubuntu/xxx` branches:

```
Dependency packages/subiquity_client has unsupported value ubuntu/lunar
```