### PR TITLE
Import common Disk & Partition extensions from UDI

### DIFF
--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -1,0 +1,13 @@
+import 'package:path/path.dart' as p;
+
+import 'types.dart';
+
+extension DiskX on Disk {
+  /// "/dev/sda" => "sda"
+  String get sysname => p.basename(path ?? '');
+}
+
+extension PartitionX on Partition {
+  /// "/dev/sda1" => "sda1"
+  String get sysname => p.basename(path ?? '');
+}

--- a/test/types_test.dart
+++ b/test/types_test.dart
@@ -1,3 +1,4 @@
+import 'package:subiquity_client/src/extensions.dart';
 import 'package:subiquity_client/src/types.dart';
 import 'package:test/test.dart';
 
@@ -157,6 +158,9 @@ void main() {
       path: '/dev/sda2',
       estimatedMinSize: 123,
     );
+
+    expect(partition.sysname, equals('sda2'));
+
     const json = <String, dynamic>{
       'size': 1,
       'number': 2,
@@ -215,6 +219,8 @@ void main() {
       model: 'QEMU',
       vendor: 'ATA',
     );
+
+    expect(disk.sysname, equals('path'));
 
     final json = <String, dynamic>{
       'id': 'test-id',


### PR DESCRIPTION
The sysname extensions are used everywhere in UDI because of being used as display names for disks and partitions. Currently, they are exported from the "disk storage service" which is being trimmed down and probably split into smaller entities. Exporting them from here makes them flow down everywhere SubiquityClient is used and where the storage service is not necessarily needed.