### PR TITLE
Revert "Pin dart_style version"

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,10 +19,6 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.2.0
-  # TODO: dart_style 2.3.0 has some formatting changes that cause differences
-  # between `dart format` and `dart pub run build_runner`. Remove this when the
-  # latest stable Dart SDK uses dart_style 2.3.0+.
-  dart_style: 2.2.5
   freezed: ^2.3.2
   json_serializable: ^6.3.1
   lints: ^2.0.1

--- a/test/status_monitor_test.mocks.dart
+++ b/test/status_monitor_test.mocks.dart
@@ -177,11 +177,10 @@ class MockHttpClient extends _i1.Mock implements _i2.HttpClient {
   @override
   set authenticate(
           _i4.Future<bool> Function(
-    Uri,
-    String,
-    String?,
-  )?
-              f) =>
+            Uri,
+            String,
+            String?,
+          )? f) =>
       super.noSuchMethod(
         Invocation.setter(
           #authenticate,
@@ -192,11 +191,10 @@ class MockHttpClient extends _i1.Mock implements _i2.HttpClient {
   @override
   set connectionFactory(
           _i4.Future<_i2.ConnectionTask<_i2.Socket>> Function(
-    Uri,
-    String?,
-    int?,
-  )?
-              f) =>
+            Uri,
+            String?,
+            int?,
+          )? f) =>
       super.noSuchMethod(
         Invocation.setter(
           #connectionFactory,
@@ -215,12 +213,11 @@ class MockHttpClient extends _i1.Mock implements _i2.HttpClient {
   @override
   set authenticateProxy(
           _i4.Future<bool> Function(
-    String,
-    int,
-    String,
-    String?,
-  )?
-              f) =>
+            String,
+            int,
+            String,
+            String?,
+          )? f) =>
       super.noSuchMethod(
         Invocation.setter(
           #authenticateProxy,
@@ -231,11 +228,10 @@ class MockHttpClient extends _i1.Mock implements _i2.HttpClient {
   @override
   set badCertificateCallback(
           bool Function(
-    _i2.X509Certificate,
-    String,
-    int,
-  )?
-              callback) =>
+            _i2.X509Certificate,
+            String,
+            int,
+          )? callback) =>
       super.noSuchMethod(
         Invocation.setter(
           #badCertificateCallback,
@@ -1102,10 +1098,9 @@ class MockHttpClientResponse extends _i1.Mock
   @override
   _i4.Future<List<int>> reduce(
           List<int> Function(
-    List<int>,
-    List<int>,
-  )?
-              combine) =>
+            List<int>,
+            List<int>,
+          )? combine) =>
       (super.noSuchMethod(
         Invocation.method(
           #reduce,
@@ -1119,8 +1114,7 @@ class MockHttpClientResponse extends _i1.Mock
     S Function(
       S,
       List<int>,
-    )?
-        combine,
+    )? combine,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1158,14 +1152,15 @@ class MockHttpClientResponse extends _i1.Mock
         returnValue: _i4.Future<bool>.value(false),
       ) as _i4.Future<bool>);
   @override
-  _i4.Future<dynamic> forEach(void Function(List<int>)? action) =>
+  _i4.Future<void> forEach(void Function(List<int>)? action) =>
       (super.noSuchMethod(
         Invocation.method(
           #forEach,
           [action],
         ),
-        returnValue: _i4.Future<dynamic>.value(),
-      ) as _i4.Future<dynamic>);
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
   @override
   _i4.Future<bool> every(bool Function(List<int>)? test) => (super.noSuchMethod(
         Invocation.method(
@@ -1259,8 +1254,7 @@ class MockHttpClientResponse extends _i1.Mock
           [bool Function(
             List<int>,
             List<int>,
-          )?
-              equals]) =>
+          )? equals]) =>
       (super.noSuchMethod(
         Invocation.method(
           #distinct,


### PR DESCRIPTION
Reverts canonical/subiquity_client.dart#53 because Dart 3 was released

> TODO: dart_style 2.3.0 has some formatting changes that cause differences
> between `dart format` and `dart pub run build_runner`. Remove this when the
> latest stable Dart SDK uses dart_style 2.3.0+.