### PR TITLE
feat: add `SubiquityClient.monitorStatus()` for convenience

### DIFF
--- a/packages/subiquity_test/lib/src/generated.mocks.dart
+++ b/packages/subiquity_test/lib/src/generated.mocks.dart
@@ -494,6 +494,14 @@ class MockSubiquityClient extends _i1.Mock implements _i4.SubiquityClient {
         )),
       ) as _i5.Future<_i2.ApplicationStatus>);
   @override
+  _i5.Stream<_i2.ApplicationStatus?> monitorStatus() => (super.noSuchMethod(
+        Invocation.method(
+          #monitorStatus,
+          [],
+        ),
+        returnValue: _i5.Stream<_i2.ApplicationStatus?>.empty(),
+      ) as _i5.Stream<_i2.ApplicationStatus?>);
+  @override
   _i5.Future<void> markConfigured(List<String>? endpointNames) =>
       (super.noSuchMethod(
         Invocation.method(


### PR DESCRIPTION
With this, the client's status changes can be conveniently listened to through the same client instance without injecting a separate status monitor service or passing both the client and a monitor around.