### PR TITLE
chore: pin analyzer version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   xdg_directories: ^0.2.0
 
 dev_dependencies:
+  analyzer: <5.13.0
   build_runner: ^2.2.0
   freezed: ^2.3.2
   json_serializable: ^6.3.1


### PR DESCRIPTION
A workaround for:
```
[SEVERE] json_serializable on lib/src/types.dart:

Could not generate `fromJson` code for `gap`.
To support the type `InvalidType` you can:
* Use `JsonConverter`
  https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonConverter-class.html
* Use `JsonKey` fields `fromJson` and `toJson`
  https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/fromJson.html
  https://pub.dev/documentation/json_annotation/latest/json_annotation/JsonKey/toJson.html
package:subiquity_client/src/types.freezed.dart:6788:21
     ╷
6788 │   final InvalidType gap;
     │                     ^^^
     ╵
```

Close: #119