### PR TITLE
chore(subiquity-test): allow newer mockito for package users

### DIFF
--- a/packages/subiquity_test/pubspec.yaml
+++ b/packages/subiquity_test/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
 
 dependencies:
   build_runner: ^2.2.0
-  mockito: 5.4.0
+  mockito: ^5.4.0
   path: ^1.8.0
   subiquity_client:
     git:

--- a/packages/subiquity_test/pubspec_overrides.yaml
+++ b/packages/subiquity_test/pubspec_overrides.yaml
@@ -1,3 +1,4 @@
 dependency_overrides:
+  mockito: 5.4.0
   subiquity_client:
     path: ../../


### PR DESCRIPTION
`subiquity_test` offers a set of ready-made mocks. While we want to generate them with a pre-determined version to ensure stable output, we don't want to force that specific version on the users of the package. Use the hat syntax for the public dependency, and override it internally to a fixed version for generation.

Before:
```
ubuntu_desktop_installer:
Resolving dependencies...
Because every version of subiquity_test from path depends on mockito 5.4.0 and ubuntu_desktop_installer depends on mockito 5.4.1, subiquity_test from path is forbidden.
So, because ubuntu_desktop_installer depends on subiquity_test from path, version solving failed.
```

After:
```
ubuntu_desktop_installer:
Resolving dependencies...
  ...
> mockito 5.4.1 (was 5.4.0)
  ...
Changed 1 dependency!
12 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
ubuntu_desktop_installer: SUCCESS
```

- https://github.com/canonical/ubuntu-desktop-installer/pull/2001