### PR TITLE
fix: catch exceptions when monitoring status

### DIFF
--- a/lib/src/status_monitor.dart
+++ b/lib/src/status_monitor.dart
@@ -54,7 +54,9 @@ class SubiquityStatusMonitor {
 
   Future<void> _listen() async {
     while (_status != null && _statusController?.isClosed == false) {
-      await _fetchStatus().then(_updateStatus);
+      await _fetchStatus()
+          .then(_updateStatus)
+          .onError((_, __) => _updateStatus(null));
     }
   }
 

--- a/test/status_monitor_test.dart
+++ b/test/status_monitor_test.dart
@@ -127,6 +127,23 @@ void main() {
     await expectLater(
         monitor.onStatusChanged, emitsInOrder([isRunning, isNull]));
   });
+
+  test('exception', () async {
+    final client = MockHttpClient();
+    when(client.openUrl('GET', noStatus))
+        .thenAnswer((_) async => statusResponse(isWaiting));
+    when(client.openUrl('GET', wasWaiting))
+        .thenAnswer((_) async => statusResponse(isRunning));
+    when(client.openUrl('GET', wasRunning))
+        .thenAnswer((_) async => throw HttpException(''));
+
+    final monitor = SubiquityStatusMonitor(client);
+
+    await monitor.start(addr);
+    expect(monitor.status, equals(isWaiting));
+    await expectLater(
+        monitor.onStatusChanged, emitsInOrder([isRunning, isNull]));
+  });
 }
 
 // null -> waiting -> running -> done


### PR DESCRIPTION
The status turns into null if Subiquity sends an error response due to an exception being thrown on the server side. We should do the same if an exception (HTTP, socket, ...) is thrown on the client side.