### PR TITLE
chore: improve makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
-generate:
+.PHONY: generate
+generate: lib/src/types.dart
+	dart run build_runner build --delete-conflicting-outputs
+
+lib/src/types.dart: subiquity
 	$(MAKE) -C generator generate
 
+.PHONY: check
 check:
 	$(MAKE) -C generator check


### PR DESCRIPTION
Let `make generate` generate Dart types from Subiquity's Python types _and_ regenerate `types.g.dart` and `types.freezed.dart` to avoid that `build_runner` has to always be run by hand afterwards. This assumes that `dart` is found in path.

### Before:
```sh
$ make (generate)
make -C generator generate
make[1]: Entering directory '/path/to/subiquity_client.dart/generator'
python3 generator.py ../subiquity/subiquity/common/types.py ../lib/src/types.dart
dart format ../lib/src/types.dart
Formatted ../lib/src/types.dart
Formatted 1 file (1 changed) in 0.13 seconds.
make[1]: Leaving directory '/path/to/subiquity_client.dart/generator'
```
```
$ dart run build_runner build --delete-conflicting-outputs
[INFO] Generating build script completed, took 152ms
[INFO] Reading cached asset graph completed, took 35ms
[INFO] Checking for updates since last build completed, took 313ms
[WARNING] json_serializable on lib/src/types.dart:
The version constraint "^4.6.0" on json_annotation allows versions before 4.8.1 which is not allowed.
[INFO] Running build completed, took 4.4s
[INFO] Caching finalized dependency graph completed, took 15ms
[INFO] Succeeded after 4.4s with 4 outputs (25 actions)
```

### After:
```sh
$ make (generate)
make -C generator generate
make[1]: Entering directory '/path/to/subiquity_client.dart/generator'
python3 generator.py ../subiquity/subiquity/common/types.py ../lib/src/types.dart
dart format ../lib/src/types.dart
Formatted ../lib/src/types.dart
Formatted 1 file (1 changed) in 0.14 seconds.
make[1]: Leaving directory '/path/to/subiquity_client.dart/generator'
dart run build_runner build --delete-conflicting-outputs
[INFO] Generating build script completed, took 158ms
[INFO] Reading cached asset graph completed, took 34ms
[INFO] Checking for updates since last build completed, took 323ms
[WARNING] json_serializable on lib/src/types.dart:
The version constraint "^4.6.0" on json_annotation allows versions before 4.8.1 which is not allowed.
[INFO] Running build completed, took 4.3s
[INFO] Caching finalized dependency graph completed, took 18ms
[INFO] Succeeded after 4.3s with 4 outputs (25 actions)
```