### PR TITLE
chore(deps): bump json_annotation to make build_runner happy

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   freezed_annotation: ^2.1.0
-  json_annotation: ^4.6.0
+  json_annotation: ^4.8.1
   meta: ^1.7.0
   package_config: ^2.0.2
   path: ^1.8.0


### PR DESCRIPTION
## Before
```
[INFO] Generating build script completed, took 161ms
[INFO] Reading cached asset graph completed, took 35ms
[INFO] Checking for updates since last build completed, took 353ms
[WARNING] json_serializable on lib/src/types.dart:
The version constraint "^4.8.0" on json_annotation allows versions before 4.8.1 which is not allowed.
[INFO] Running build completed, took 4.2s
[INFO] Caching finalized dependency graph completed, took 24ms
[INFO] Succeeded after 4.3s with 4 outputs (4 actions)
```

## After
```
[INFO] Generating build script completed, took 174ms
[INFO] Reading cached asset graph completed, took 38ms
[INFO] Checking for updates since last build completed, took 324ms
[INFO] Running build completed, took 4.2s
[INFO] Caching finalized dependency graph completed, took 15ms
[INFO] Succeeded after 4.2s with 4 outputs (4 actions)
```