### PR TITLE
feat: track subiquity's ubuntu/mantic branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "subiquity_client/subiquity"]
 	path = subiquity
 	url = https://github.com/canonical/subiquity.git
-	branch = main
+	branch = ubuntu/mantic


### PR DESCRIPTION
Updates the current submodule reference to `ubuntu/mantic` and makes sure that dependabot uses the same reference.